### PR TITLE
Switch test runner image to amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install QEMU and dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
         with:
@@ -34,7 +28,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: false
           load: true
           tags: exercism/arm64-assembly-test-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
-FROM arm64v8/alpine:3.20.1
+FROM ubuntu:24.04
 
 # install packages required to run the tests
-RUN apk add --no-cache jq coreutils gcc libc-dev make python3
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install --no-install-recommends \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross \
+        make \
+        python3 \
+        qemu-user \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -31,5 +31,5 @@ test_file=$(echo "${slug}" | sed 's/-/_/g')_test.c
 cd "${solution_dir}" || exit
 sed -i 's#TEST_IGNORE();#// &#' "${test_file}"
 make clean
-stdbuf -oL make > "${output_dir}/results.out" 2>&1
+make > "${output_dir}/results.out" 2>&1
 python3 "${cwd}"/process_results.py "${output_dir}/results.out"

--- a/tests/all-fail/Makefile
+++ b/tests/all-fail/Makefile
@@ -1,32 +1,28 @@
-# Variables
-AS = as
-CC = gcc
+AS = aarch64-linux-gnu-as
+CC = aarch64-linux-gnu-gcc
 
 CFLAGS = -g -Wall -Wextra -pedantic -Werror
 LDFLAGS =
-ASFLAGS = -g
+
+ALL_LDFLAGS = -pie -Wl,--fatal-warnings
 
 ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-ALL_ASFLAGS = $(ASFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
 
-# File lists
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
 ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
-# Commands
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-# Targets
 all: tests
-	@./$<
+	@qemu-aarch64 -L /usr/aarch64-linux-gnu ./$<
 
 tests: $(ALL_OBJS)
 	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
-	@$(AS) $(ALL_ASFLAGS) -o $@ $<
+	@$(AS) -o $@ $<
 
 %.o: %.c
 	@$(CC_CMD)

--- a/tests/empty-file/Makefile
+++ b/tests/empty-file/Makefile
@@ -1,32 +1,28 @@
-# Variables
-AS = as
-CC = gcc
+AS = aarch64-linux-gnu-as
+CC = aarch64-linux-gnu-gcc
 
 CFLAGS = -g -Wall -Wextra -pedantic -Werror
 LDFLAGS =
-ASFLAGS = -g
+
+ALL_LDFLAGS = -pie -Wl,--fatal-warnings
 
 ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-ALL_ASFLAGS = $(ASFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
 
-# File lists
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
 ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
-# Commands
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-# Targets
 all: tests
-	@./$<
+	@qemu-aarch64 -L /usr/aarch64-linux-gnu ./$<
 
 tests: $(ALL_OBJS)
 	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
-	@$(AS) $(ALL_ASFLAGS) -o $@ $<
+	@$(AS) -o $@ $<
 
 %.o: %.c
 	@$(CC_CMD)

--- a/tests/empty-file/expected_results.json
+++ b/tests/empty-file/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: empty_file_test.o: in function `test_add':\n/opt/test-runner/tests/empty-file/empty_file_test.c:14:(.text+0x20): undefined reference to `add'\ncollect2: error: ld returned 1 exit status\nmake: *** [Makefile:26: tests] Error 1\n",
+  "message": "/usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/bin/ld: empty_file_test.o: in function `test_add':\n/opt/test-runner/tests/empty-file/empty_file_test.c:14:(.text+0x20): undefined reference to `add'\ncollect2: error: ld returned 1 exit status\nmake: *** [Makefile:22: tests] Error 1\n",
   "tests": []
 }

--- a/tests/partial-fail/Makefile
+++ b/tests/partial-fail/Makefile
@@ -1,32 +1,28 @@
-# Variables
-AS = as
-CC = gcc
+AS = aarch64-linux-gnu-as
+CC = aarch64-linux-gnu-gcc
 
 CFLAGS = -g -Wall -Wextra -pedantic -Werror
 LDFLAGS =
-ASFLAGS = -g
+
+ALL_LDFLAGS = -pie -Wl,--fatal-warnings
 
 ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-ALL_ASFLAGS = $(ASFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
 
-# File lists
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
 ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
-# Commands
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-# Targets
 all: tests
-	@./$<
+	@qemu-aarch64 -L /usr/aarch64-linux-gnu ./$<
 
 tests: $(ALL_OBJS)
 	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
-	@$(AS) $(ALL_ASFLAGS) -o $@ $<
+	@$(AS) -o $@ $<
 
 %.o: %.c
 	@$(CC_CMD)

--- a/tests/success/Makefile
+++ b/tests/success/Makefile
@@ -1,32 +1,28 @@
-# Variables
-AS = as
-CC = gcc
+AS = aarch64-linux-gnu-as
+CC = aarch64-linux-gnu-gcc
 
 CFLAGS = -g -Wall -Wextra -pedantic -Werror
 LDFLAGS =
-ASFLAGS = -g
+
+ALL_LDFLAGS = -pie -Wl,--fatal-warnings
 
 ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-ALL_ASFLAGS = $(ASFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
 
-# File lists
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
 ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
-# Commands
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-# Targets
 all: tests
-	@./$<
+	@qemu-aarch64 -L /usr/aarch64-linux-gnu ./$<
 
 tests: $(ALL_OBJS)
 	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
-	@$(AS) $(ALL_ASFLAGS) -o $@ $<
+	@$(AS) -o $@ $<
 
 %.o: %.c
 	@$(CC_CMD)

--- a/tests/syntax-error/Makefile
+++ b/tests/syntax-error/Makefile
@@ -1,32 +1,28 @@
-# Variables
-AS = as
-CC = gcc
+AS = aarch64-linux-gnu-as
+CC = aarch64-linux-gnu-gcc
 
 CFLAGS = -g -Wall -Wextra -pedantic -Werror
 LDFLAGS =
-ASFLAGS = -g
+
+ALL_LDFLAGS = -pie -Wl,--fatal-warnings
 
 ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-ALL_ASFLAGS = $(ASFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
 
-# File lists
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
 ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
-# Commands
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-# Targets
 all: tests
-	@./$<
+	@qemu-aarch64 -L /usr/aarch64-linux-gnu ./$<
 
 tests: $(ALL_OBJS)
 	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
-	@$(AS) $(ALL_ASFLAGS) -o $@ $<
+	@$(AS) -o $@ $<
 
 %.o: %.c
 	@$(CC_CMD)

--- a/tests/syntax-error/expected_results.json
+++ b/tests/syntax-error/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "fake.s: Assembler messages:\nfake.s:5: Error: unknown mnemonic `return' -- `return'\nmake: *** [Makefile:29: fake.o] Error 1\n",
+  "message": "fake.s: Assembler messages:\nfake.s:5: Error: unknown mnemonic `return' -- `return'\nmake: *** [Makefile:25: fake.o] Error 1\n",
   "tests": []
 }


### PR DESCRIPTION
This changes the test runner image to be based on a amd64 ubuntu:24.04 base image. To build students' solutions, we use a cross toolchain. To run solutions, we use qemu-user. Students are asked to use the exact same workflow. To this end we unify the tests Makefiles with those from the arm64-assembly exercises repository.

Image size:
```
$ docker images
REPOSITORY                            TAG       IMAGE ID       CREATED          SIZE
exercism/arm64-assembly-test-runner   latest    05ccffd0b87d   14 minutes ago   369MB
```

Fixes #8 